### PR TITLE
add DragSelect

### DIFF
--- a/_posts/2017-09-06-dragselect.md
+++ b/_posts/2017-09-06-dragselect.md
@@ -8,4 +8,4 @@ ie10: true
 categories: [Drag, Select, Selection]
 tags: [Selectable, jquery-selectable, jquery-ui]
 ---
-Easy javascript selection functionality done right. Mimics operating system file selection behaviour.
+Easy javascript selection functionality done right. Mimics operating system file selection behavior.

--- a/_posts/2017-09-06-dragselect.md
+++ b/_posts/2017-09-06-dragselect.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: DragSelect
+link: "https://github.com/ThibaultJanBeyer/DragSelect"
+ie8: false
+ie9: true
+ie10: true
+categories: [Drag, Select, Selection]
+tags: [Selectable, jquery-selectable, jquery-ui]
+---
+Easy javascript selection functionality done right. Mimics operating system file selection behaviour.


### PR DESCRIPTION
DragSelect is a VanillaJS plugin that mimics operating system file selection behavior. It lets you select dom nodes.

So I was writing an electron app and needed some selection. Unfortunately, after some research, I did not find any smart plugin that did not require jQuery or some other framework, so I wrote it myself.
It took quite long to write it, so I made a plugin out of it that you can easily use yourself. It’s super small and does just that. I called it DragSelect and it’s on Github.

The cool thing about this is that you have **0 dependencies** and thus can use it with any framework you like.

The selection algorithm works like a charm and even gives you an independent multi-selection with modifier keys for free.

Please see the corresponding [github page](https://github.com/thibaultjanbeyer/DragSelect).